### PR TITLE
fix: SyntaxError: Decorators must not be followed by a semicolon

### DIFF
--- a/src/AudioNode.js
+++ b/src/AudioNode.js
@@ -70,9 +70,9 @@ export default class AudioNode extends EventTarget {
   @props.enums([ "speakers", "discrete" ])
   channelInterpretation() {}
 
-  @methods.param("destination", validators.isAudioSource);
-  @methods.param("[ output ]", validators.isPositiveInteger);
-  @methods.param("[ input ]", validators.isPositiveInteger);
+  @methods.param("destination", validators.isAudioSource)
+  @methods.param("[ output ]", validators.isPositiveInteger)
+  @methods.param("[ input ]", validators.isPositiveInteger)
   @methods.contract({
     precondition(destination, output = 0, input = 0) {
       if (this.$context !== destination.$context) {

--- a/src/ScriptProcessorNode.js
+++ b/src/ScriptProcessorNode.js
@@ -46,7 +46,7 @@ export default class ScriptProcessorNode extends AudioNode {
     return this._.bufferSize;
   }
 
-  @props.on("audioprocess");
+  @props.on("audioprocess")
   onaudioprocess() {}
 
   __process(inNumSamples) {


### PR DESCRIPTION
Was getting this error while building:
```
SyntaxError: src/AudioNode.js: Decorators must not be followed by a semicolon (73:58)
  71 |   channelInterpretation() {}
  72 |
> 73 |   @methods.param("destination", validators.isAudioSource);
     |                                                           ^
  74 |   @methods.param("[ output ]", validators.isPositiveInteger);
  75 |   @methods.param("[ input ]", validators.isPositiveInteger);
  76 |   @methods.contract({
```